### PR TITLE
Add workflow_dispatch trigger.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:


### PR DESCRIPTION
The current triggers require a push or PR to exercise the pipeline. Adding this trigger will allow the pipeline to be run without having to modify any code.